### PR TITLE
Strip regional suffixes on normalization before converting ISO 639-1 codes to 639-2/T

### DIFF
--- a/Jellyfin.Plugin.MediaDash.Tests/LanguageHelperTests.cs
+++ b/Jellyfin.Plugin.MediaDash.Tests/LanguageHelperTests.cs
@@ -15,6 +15,9 @@ public class LanguageHelperTests
     [InlineData("ger", "deu")]
     [InlineData("chi", "zho")]
     [InlineData("dut", "nld")]
+    [InlineData("es-MX", "spa")]
+    [InlineData("ES_mx", "spa")]
+    [InlineData("en-US", "eng")]
     public void Normalize_MapsBibliographicVariantsAndCase(string? input, string expected)
     {
         Assert.Equal(expected, LanguageHelper.Normalize(input));

--- a/Jellyfin.Plugin.MediaDash/Scanners/LanguageHelper.cs
+++ b/Jellyfin.Plugin.MediaDash/Scanners/LanguageHelper.cs
@@ -45,6 +45,13 @@ public static class LanguageHelper
         }
 
         var lang = language.Trim().ToLowerInvariant();
+
+        var regionSeparator = lang.IndexOfAny(['-', '_']);
+        if (regionSeparator >= 0)
+        {
+            lang = lang[..regionSeparator];
+        }
+
         // ISO 639-1 (2-letter) → 639-2/T (3-letter) via CultureInfo. Without this, an "en"-tagged track
         // never matches an allowed list of ["eng"] and gets flagged for removal — including the file's
         // only English audio track when Spanish also exists ("last audio" invariant wouldn't save it).


### PR DESCRIPTION
## Summary

Updated language normalization to strip regional suffixes before converting ISO 639-1 codes. This ensures tags like `es-MX` and `en-US` correctly normalize to spa and eng

## Testing

<!-- What did you verify? Local build, unit tests, live Jellyfin install? -->

- [X] `dotnet build` clean
- [X] `dotnet test` passes
- [] Manual verification in a live Jellyfin server (if UI or fixer changes)

## Safety invariants

<!-- Only tick each box if you actually understood and preserved the invariant. Leave unchecked if not applicable. -->

- [X] Does not touch files outside configured library paths.
- [X] Does not remove the last audio track or the last video stream.
- [X] Does not replace a file whose transcode/remux failed verification.
- [X] Does not move a file to a target outside a Jellyfin library root.
- [X] Free-space check present before any transcode.
